### PR TITLE
feat(i18n): 根级 ConfigProvider 与 dayjs locale 联动，使 DatePicker 随语言切换

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <div id="app">
+    <a-config-provider :locale="antdLocale">
     <a-layout style="min-height: 100vh">
       <!-- <a-layout-header v-if="!isLandingRoute" class="app-header">
         <div class="header-inner">
@@ -46,6 +47,7 @@
         </div>
       </a-layout-footer> -->
     </a-layout>
+    </a-config-provider>
   </div>
 </template>
 
@@ -53,17 +55,25 @@
 import { computed, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import dayjs from 'dayjs'
+import 'dayjs/locale/zh-cn'
+import 'dayjs/locale/ja'
 import { setAppLocale, type AppLocale } from '@/i18n'
+import { getAntdLocale, getDayjsLocaleKey } from '@/i18n/antd-locale'
 
 const { t, locale } = useI18n()
 const route = useRoute()
 const year = new Date().getFullYear()
 const isLandingRoute = computed(() => route.name === 'Landing')
 
+const antdLocale = computed(() => getAntdLocale(locale.value as AppLocale))
+
 watch(
   locale,
   (nextLocale) => {
-    setAppLocale(nextLocale as AppLocale)
+    const appLocale = nextLocale as AppLocale
+    setAppLocale(appLocale)
+    dayjs.locale(getDayjsLocaleKey(appLocale))
     document.title = t('app.title')
   },
   { immediate: true }

--- a/frontend/src/i18n/antd-locale.ts
+++ b/frontend/src/i18n/antd-locale.ts
@@ -1,0 +1,26 @@
+import enUS from 'ant-design-vue/es/locale/en_US'
+import jaJP from 'ant-design-vue/es/locale/ja_JP'
+import zhCN from 'ant-design-vue/es/locale/zh_CN'
+import type { AppLocale } from './messages'
+
+type AntdLocale = typeof zhCN
+
+const antdLocales: Record<AppLocale, AntdLocale> = {
+  'zh-CN': zhCN,
+  'en-US': enUS,
+  'ja-JP': jaJP,
+}
+
+const dayjsLocaleKeys: Record<AppLocale, string> = {
+  'zh-CN': 'zh-cn',
+  'en-US': 'en',
+  'ja-JP': 'ja',
+}
+
+export function getAntdLocale(locale: AppLocale): AntdLocale {
+  return antdLocales[locale]
+}
+
+export function getDayjsLocaleKey(locale: AppLocale): string {
+  return dayjsLocaleKeys[locale]
+}


### PR DESCRIPTION
- 新增 i18n/antd-locale.ts，穷尽映射 AppLocale → ant-design-vue / dayjs
- App.vue 使用 a-config-provider，并在语言 watch 中同步 dayjs.locale
- Home/Landing 无需改动，子树继承全局 locale

这次改动主要解决的是：切换 vue-i18n 语言（中/英/日）时，a-date-picker 没有完整跟着变的问题。