### PR TITLE
fix: correct back container selector typo

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -7641,7 +7641,7 @@ textarea.form-control {
   background-color: #e5e5e5;
 }
 
-.rotating-card .back-contaier {
+.rotating-card .back-container {
   background-color: white;
   padding: 30px 15px;
 }


### PR DESCRIPTION
## Summary
- rename the rotating card back selector from .back-contaier to .back-container
- keep the icon font class typo unchanged because it appears to be an upstream class name

## Verification
- reran typos scan after the change
- remaining typo hit is only the icon font class false positive

Fixes #12