### PR TITLE
feat(plan): 支持历史计划回补，并修复仅配置 .env 时 LLM 环境变量不生效问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 backend/runtime_settings.json
+backend/data/trip_tasks

--- a/backend/app/agents/trip_planner_agent.py
+++ b/backend/app/agents/trip_planner_agent.py
@@ -2,6 +2,7 @@
 
 import json
 import asyncio
+import os
 from typing import Dict, Any, List, Callable, Awaitable, Optional
 from hello_agents import SimpleAgent
 from hello_agents.tools import MCPTool
@@ -189,6 +190,9 @@ class MultiAgentTripPlanner:
                 env={"AMAP_MAPS_API_KEY": settings.vite_amap_web_key},
                 auto_expand=True
             )
+            # 当前 hello_agents 版本不会自动把 MCPTool 标记为 expandable，
+            # 手动开启后才能把 `amap_maps_*` 子工具注册到 Agent。
+            self.amap_tool.expandable = True
 
             # 取消高德景点 Agent,改用原生小红书服务
             # print("  - 创建景点搜索Agent...")
@@ -307,8 +311,18 @@ class MultiAgentTripPlanner:
             # ========== 串行阶段: 步骤4 整合生成 ==========
             print("📋 步骤4: 生成行程计划...")
             await self._emit_progress(progress_callback, "planning", "正在生成旅行计划...", 85)
-            planner_query = self._build_planner_query(request, attraction_response, weather_response, hotel_response)
-            planner_response = await asyncio.to_thread(self.planner_agent.run, planner_query)
+            attraction_context = self._prepare_planner_context("attractions", attraction_response)
+            weather_context = self._prepare_planner_context("weather", weather_response)
+            hotel_context = self._prepare_planner_context("hotels", hotel_response)
+            print(
+                f"🧾 规划上下文长度: 景点={len(attraction_context)} 天气={len(weather_context)} 酒店={len(hotel_context)}"
+            )
+            planner_response = await self._run_planner_with_retry(
+                request,
+                attraction_context,
+                weather_context,
+                hotel_context,
+            )
             print(f"行程规划结果: {planner_response[:300]}...\n")
 
             # 解析最终计划
@@ -339,6 +353,88 @@ class MultiAgentTripPlanner:
         query = f"请使用amap_maps_text_search工具搜索{request.city}的{keywords}相关的景点。\n非常重要：你必须直接输出 `[TOOL_CALL:amap_maps_text_search:keywords={keywords},city={request.city}]`，不要附带任何多余的 JSON 或文字说明！"
         return query
 
+    def _prepare_planner_context(self, category: str, text: str) -> str:
+        """压缩上下文，避免把冗长失败提示和超长文本直接塞给规划模型。"""
+        limits = {
+            "attractions": 2400,
+            "weather": 600,
+            "hotels": 900,
+        }
+        fallbacks = {
+            "attractions": "景点信息有限。请仅基于当前已知热门景点生成稳妥行程，不要虚构偏门景点。",
+            "weather": "天气信息暂未成功获取。请提供室内/室外可替换方案，并提醒用户出发前再次查看实时天气。",
+            "hotels": "酒店检索暂未成功获取。请根据用户住宿偏好与主要景点分布，给出交通便利商圈的住宿建议，并明确属于备选方案。",
+        }
+        failure_markers = (
+            "未找到工具",
+            "工具调用失败",
+            "查询失败",
+            "暂时无法",
+            "Request timed out",
+            "system cpu overloaded",
+        )
+
+        normalized = (text or "").strip()
+        if not normalized:
+            return fallbacks[category]
+
+        if any(marker in normalized for marker in failure_markers):
+            return fallbacks[category]
+
+        if category == "attractions" and normalized.startswith("这是小红书热门精选游记的提取结果"):
+            lines = [line for line in normalized.splitlines() if line.strip()]
+            normalized = "\n".join(lines[:7])
+
+        limit = limits[category]
+        if len(normalized) > limit:
+            normalized = normalized[:limit].rstrip() + "\n...(上下文已截断)"
+
+        return normalized
+
+    async def _run_planner_with_retry(
+        self,
+        request: TripRequest,
+        attractions: str,
+        weather: str,
+        hotels: str,
+    ) -> str:
+        """规划阶段使用更长超时，并在超时后用更精简的上下文再试一次。"""
+        timeout = int(os.getenv("TRIP_PLANNER_TIMEOUT", "180"))
+        max_tokens = int(os.getenv("TRIP_PLANNER_MAX_TOKENS", "2200"))
+        planner_query = self._build_planner_query(request, attractions, weather, hotels)
+
+        try:
+            return await asyncio.to_thread(
+                self.planner_agent.run,
+                planner_query,
+                timeout=timeout,
+                temperature=0.2,
+                max_tokens=max_tokens,
+            )
+        except Exception as exc:
+            err_text = str(exc).lower()
+            if "timeout" not in err_text and "timed out" not in err_text:
+                raise
+
+            print("⚠️  首次行程规划超时，正在使用精简上下文重试一次...")
+            compact_query = self._build_planner_query(
+                request,
+                self._prepare_planner_context("attractions", attractions[:1200]),
+                self._prepare_planner_context("weather", weather[:300]),
+                self._prepare_planner_context("hotels", hotels[:450]),
+            )
+            compact_query += (
+                "\n\n**补充要求:** 如果部分辅助信息不足，请使用保守、常见、可执行的建议补齐，"
+                "但必须输出完整合法的 JSON，不要输出解释性文字。"
+            )
+            return await asyncio.to_thread(
+                self.planner_agent.run,
+                compact_query,
+                timeout=timeout,
+                temperature=0.2,
+                max_tokens=min(max_tokens, 1800),
+            )
+
     def _build_planner_query(self, request: TripRequest, attractions: str, weather: str, hotels: str = "") -> str:
         """构建行程规划查询"""
         query = f"""请根据以下信息生成{request.city}的{request.travel_days}天旅行计划:
@@ -367,6 +463,7 @@ class MultiAgentTripPlanner:
 3. 考虑景点之间的距离和交通方式
 4. 返回完整的JSON格式数据
 5. 景点的经纬度坐标要真实准确
+6. 如果天气或酒店信息不足，请基于保守、通用的旅行建议补齐，但不要输出“无法查询”之类的解释文字
 """
         if request.free_text_input:
             query += f"\n**额外要求:** {request.free_text_input}"

--- a/backend/app/api/routes/trip.py
+++ b/backend/app/api/routes/trip.py
@@ -1,8 +1,11 @@
 """旅行规划 API 路由 - WebSocket 同步 + 轮询兼容模式"""
 
 import asyncio
+import json
 import traceback
 import uuid
+from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict
 
 from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
@@ -16,6 +19,7 @@ router = APIRouter(prefix="/trip", tags=["旅行规划"])
 # 内存任务存储（单实例部署足够）
 _tasks: Dict[str, Dict[str, Any]] = {}
 _FINAL_TASK_STATUS = {"completed", "failed"}
+_TASKS_DATA_DIR = Path(__file__).resolve().parents[3] / "data" / "trip_tasks"
 
 
 def _create_task_state(task_id: str) -> Dict[str, Any]:
@@ -29,6 +33,7 @@ def _create_task_state(task_id: str) -> Dict[str, Any]:
         "message": "任务已提交，等待执行...",
         "result": None,
         "error": None,
+        "request_payload": None,
         "subscribers": [],  # list[asyncio.Queue]
     }
 
@@ -39,6 +44,164 @@ def _serialize_result(result: Any) -> Any:
     if hasattr(result, "model_dump"):
         return result.model_dump(mode="json")
     return result
+
+
+def _task_file_path(task_id: str) -> Path:
+    """获取任务持久化文件路径。"""
+    return _TASKS_DATA_DIR / f"{task_id}.json"
+
+
+def _normalize_loaded_task(task_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """将磁盘中的任务结构恢复为内存可用格式。"""
+    task = _create_task_state(task_id)
+    task.update(
+        {
+            "plan_id": payload.get("plan_id", task_id),
+            "status": payload.get("status", "failed"),
+            "stage": payload.get("stage", "failed"),
+            "progress": payload.get("progress", 100),
+            "message": payload.get("message", ""),
+            "result": payload.get("result"),
+            "error": payload.get("error"),
+            "request_payload": payload.get("request_payload"),
+        }
+    )
+    task["subscribers"] = []
+
+    # 服务重启后，处理中任务无法恢复执行，直接标记为失败，避免前端无限等待。
+    if task["status"] not in _FINAL_TASK_STATUS:
+        task["status"] = "failed"
+        task["stage"] = "failed"
+        task["progress"] = 100
+        task["error"] = "服务已重启，未完成的旅行规划任务无法恢复，请重新生成。"
+        task["message"] = task["error"]
+
+    return task
+
+
+def _persist_task_state(task_id: str, task: Dict[str, Any]) -> None:
+    """将任务状态持久化到本地 JSON 文件。"""
+    try:
+        _TASKS_DATA_DIR.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "task_id": task_id,
+            "plan_id": task.get("plan_id", task_id),
+            "status": task.get("status", "processing"),
+            "stage": task.get("stage", ""),
+            "progress": task.get("progress", 0),
+            "message": task.get("message", ""),
+            "result": _serialize_result(task.get("result")),
+            "error": task.get("error"),
+            "request_payload": task.get("request_payload"),
+        }
+        target = _task_file_path(task_id)
+        tmp = target.with_suffix(".json.tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+        tmp.replace(target)
+    except Exception as e:
+        print(f"⚠️  持久化任务 {task_id} 失败: {e}")
+
+
+def _load_task_from_disk(task_id: str) -> Dict[str, Any] | None:
+    """从磁盘加载单个任务。"""
+    path = _task_file_path(task_id)
+    if not path.exists():
+        return None
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        if not isinstance(payload, dict):
+            return None
+        task = _normalize_loaded_task(task_id, payload)
+        _tasks[task_id] = task
+        return task
+    except Exception as e:
+        print(f"⚠️  读取任务 {task_id} 失败: {e}")
+        return None
+
+
+def _load_persisted_tasks() -> None:
+    """服务启动时预加载历史任务。"""
+    if not _TASKS_DATA_DIR.exists():
+        return
+
+    loaded = 0
+    for path in sorted(_TASKS_DATA_DIR.glob("*.json")):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                payload = json.load(f)
+            if not isinstance(payload, dict):
+                continue
+            task_id = str(payload.get("task_id") or path.stem)
+            _tasks[task_id] = _normalize_loaded_task(task_id, payload)
+            loaded += 1
+        except Exception as e:
+            print(f"⚠️  加载历史任务 {path.name} 失败: {e}")
+
+    if loaded:
+        print(f"📦 已加载 {loaded} 个持久化旅行任务")
+
+
+def _get_task(task_id: str) -> Dict[str, Any] | None:
+    """优先从内存读取任务，不存在时回退到磁盘。"""
+    return _tasks.get(task_id) or _load_task_from_disk(task_id)
+
+
+def _build_history_item(task_id: str, payload: Dict[str, Any], updated_at: str) -> Dict[str, Any] | None:
+    """从持久化任务中提取首页历史列表所需的摘要。"""
+    if payload.get("status") != "completed":
+        return None
+
+    result = payload.get("result") or {}
+    plan = result.get("data") or {}
+    request_payload = payload.get("request_payload") or {}
+
+    city = plan.get("city") or request_payload.get("city") or ""
+    start_date = plan.get("start_date") or request_payload.get("start_date") or ""
+    end_date = plan.get("end_date") or request_payload.get("end_date") or ""
+    days = plan.get("days") or []
+    travel_days = request_payload.get("travel_days") or (len(days) if isinstance(days, list) else 0)
+    overall_suggestions = plan.get("overall_suggestions") or result.get("message") or ""
+
+    if not city:
+        return None
+
+    return {
+        "plan_id": payload.get("plan_id", task_id),
+        "task_id": task_id,
+        "city": city,
+        "start_date": start_date,
+        "end_date": end_date,
+        "travel_days": travel_days,
+        "updated_at": updated_at,
+        "overall_suggestions": overall_suggestions,
+    }
+
+
+def _load_history_items(limit: int = 10) -> list[Dict[str, Any]]:
+    """按最近更新时间返回已完成的历史计划摘要。"""
+    if not _TASKS_DATA_DIR.exists():
+        return []
+
+    items: list[Dict[str, Any]] = []
+    for path in sorted(_TASKS_DATA_DIR.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                payload = json.load(f)
+            if not isinstance(payload, dict):
+                continue
+            updated_at = datetime.fromtimestamp(path.stat().st_mtime).isoformat(timespec="seconds")
+            item = _build_history_item(str(payload.get("task_id") or path.stem), payload, updated_at)
+            if item:
+                items.append(item)
+            if len(items) >= limit:
+                break
+        except Exception as e:
+            print(f"⚠️  读取历史任务 {path.name} 失败: {e}")
+
+    return items
 
 
 def _build_task_event(task_id: str, task: Dict[str, Any], include_result: bool = True) -> Dict[str, Any]:
@@ -53,6 +216,8 @@ def _build_task_event(task_id: str, task: Dict[str, Any], include_result: bool =
     }
     if task.get("error"):
         event["error"] = task["error"]
+    if task.get("status") == "failed" and task.get("request_payload") is not None:
+        event["request_payload"] = task["request_payload"]
     if include_result and task.get("result") is not None:
         event["result"] = _serialize_result(task["result"])
     return event
@@ -103,6 +268,7 @@ async def _update_task_state(
     if error is not None:
         task["error"] = error
 
+    _persist_task_state(task_id, task)
     event = _build_task_event(task_id, task, include_result=True)
     _broadcast_task_event(task_id, event)
 
@@ -116,6 +282,8 @@ async def plan_trip(request: TripRequest):
     """提交旅行规划任务（立即返回 task_id）。"""
     task_id = str(uuid.uuid4())[:8]
     _tasks[task_id] = _create_task_state(task_id)
+    _tasks[task_id]["request_payload"] = request.model_dump(mode="json")
+    _persist_task_state(task_id, _tasks[task_id])
 
     print(f"\n{'=' * 60}")
     print(f"📥 收到旅行规划请求 (task_id={task_id}):")
@@ -223,7 +391,7 @@ async def _run_trip_planning(task_id: str, request: TripRequest):
 async def trip_task_ws(websocket: WebSocket, task_id: str):
     """WebSocket 订阅任务状态。"""
     await websocket.accept()
-    task = _tasks.get(task_id)
+    task = _get_task(task_id)
     if not task:
         await websocket.send_json(
             {
@@ -272,16 +440,29 @@ async def trip_task_ws(websocket: WebSocket, task_id: str):
 
 
 @router.get(
+    "/history",
+    summary="最近历史计划",
+    description="返回最近成功生成的旅行计划摘要，供首页快速找回历史计划",
+)
+async def get_trip_history(limit: int = 10):
+    """查询最近的历史计划摘要。"""
+    safe_limit = max(1, min(int(limit or 10), 50))
+    return {
+        "items": _load_history_items(safe_limit),
+    }
+
+
+@router.get(
     "/status/{task_id}",
     summary="查询任务状态",
     description="轮询旅行规划任务的执行状态和结果（兼容旧客户端）",
 )
 async def get_task_status(task_id: str):
     """查询任务执行状态。"""
-    if task_id not in _tasks:
+    task = _get_task(task_id)
+    if task is None:
         raise HTTPException(status_code=404, detail="任务不存在")
 
-    task = _tasks[task_id]
     if task["status"] == "completed":
         return {
             "task_id": task_id,
@@ -295,6 +476,7 @@ async def get_task_status(task_id: str):
             "plan_id": task.get("plan_id", task_id),
             "status": "failed",
             "error": task.get("error", ""),
+            "request_payload": task.get("request_payload"),
         }
     return {
         "task_id": task_id,
@@ -323,3 +505,6 @@ async def health_check():
         }
     except Exception as e:
         raise HTTPException(status_code=503, detail=f"服务不可用: {str(e)}")
+
+
+_load_persisted_tasks()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,6 +4,7 @@ import os
 import json
 from pathlib import Path
 from typing import List, Dict, Any
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings
 from dotenv import load_dotenv
 
@@ -40,9 +41,18 @@ class Settings(BaseSettings):
     xhs_cookie: str = ""
 
     # LLM配置 (从环境变量读取,由HelloAgents管理)
-    openai_api_key: str = ""
-    openai_base_url: str = "https://api.openai.com/v1"
-    openai_model: str = "gpt-4"
+    openai_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("OPENAI_API_KEY", "LLM_API_KEY"),
+    )
+    openai_base_url: str = Field(
+        default="https://api.openai.com/v1",
+        validation_alias=AliasChoices("OPENAI_BASE_URL", "LLM_BASE_URL"),
+    )
+    openai_model: str = Field(
+        default="gpt-4",
+        validation_alias=AliasChoices("OPENAI_MODEL", "LLM_MODEL_ID"),
+    )
 
     # 日志配置
     log_level: str = "INFO"

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,5 +1,7 @@
 """LLM服务模块"""
 
+import os
+
 from hello_agents import HelloAgentsLLM
 from ..config import get_settings
 
@@ -18,10 +20,33 @@ def get_llm() -> HelloAgentsLLM:
     
     if _llm_instance is None:
         settings = get_settings()
-        
-        # HelloAgentsLLM会自动从环境变量读取配置
-        # 包括OPENAI_API_KEY, OPENAI_BASE_URL, OPENAI_MODEL等
-        _llm_instance = HelloAgentsLLM()
+
+        api_key = (
+            settings.openai_api_key
+            or os.getenv("LLM_API_KEY")
+            or os.getenv("OPENAI_API_KEY")
+            or ""
+        )
+        base_url = (
+            settings.openai_base_url
+            or os.getenv("LLM_BASE_URL")
+            or os.getenv("OPENAI_BASE_URL")
+            or "https://api.openai.com/v1"
+        )
+        model = (
+            settings.openai_model
+            or os.getenv("LLM_MODEL_ID")
+            or os.getenv("OPENAI_MODEL")
+            or "gpt-4"
+        )
+        timeout = int(os.getenv("LLM_TIMEOUT", "60"))
+
+        _llm_instance = HelloAgentsLLM(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+        )
         
         # 【关键修复】：针对第三方中转API可能开启了 Cloudflare/WAF 拦截 Python 默认爬虫特征的情况
         # 我们手动覆盖底层的 OpenAI client，加入伪装的浏览器 User-Agent

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -107,6 +107,15 @@
     "specialNeedsPlaceholder": "Tell me your special needs, e.g. traveling with seniors, want to see sunrise, pollen allergy...",
     "submit": "Start Planning",
     "submitting": "AI is planning...",
+    "history": {
+      "eyebrow": "Recently Saved",
+      "title": "Plan History",
+      "refresh": "Refresh",
+      "open": "Open",
+      "empty": "No saved plans yet",
+      "updatedAt": "Updated",
+      "loadFailed": "Failed to load plan history"
+    },
     "loading": {
       "initializing": "Initializing...",
       "searchingAttractions": "Searching attractions...",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -107,6 +107,15 @@
     "specialNeedsPlaceholder": "特別な要望を入力してください（例：高齢者同行、日の出を見たい、花粉アレルギーなど）",
     "submit": "旅程を作成する",
     "submitting": "AI がプランを作成中…",
+    "history": {
+      "eyebrow": "最近保存",
+      "title": "履歴プラン",
+      "refresh": "更新",
+      "open": "詳細を見る",
+      "empty": "保存済みのプランはありません",
+      "updatedAt": "更新",
+      "loadFailed": "履歴プランの読み込みに失敗しました"
+    },
     "loading": {
       "initializing": "初期化中...",
       "searchingAttractions": "観光地を検索中...",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -107,6 +107,15 @@
     "specialNeedsPlaceholder": "告诉我你的特殊需求，比如：带老人出行、想看日出、对花粉过敏……",
     "submit": "开始规划旅程",
     "submitting": "AI 正在规划中…",
+    "history": {
+      "eyebrow": "最近保存",
+      "title": "历史计划",
+      "refresh": "刷新",
+      "open": "查看详情",
+      "empty": "暂无历史计划",
+      "updatedAt": "更新于",
+      "loadFailed": "读取历史计划失败"
+    },
     "loading": {
       "initializing": "正在初始化...",
       "searchingAttractions": "正在搜索景点...",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3,6 +3,7 @@ import type {
   BackendRuntimeSettings,
   RuntimeSettings,
   TripFormData,
+  TripHistoryItem,
   TripPlanResponse,
   TripTaskEvent,
 } from '@/types'
@@ -51,6 +52,10 @@ interface RuntimeSettingsApiResponse {
   success: boolean
   message?: string
   data?: Partial<BackendRuntimeSettings>
+}
+
+interface TripHistoryResponse {
+  items?: TripHistoryItem[]
 }
 
 export const getRuntimeApiBaseUrl = (): string => {
@@ -230,6 +235,18 @@ export async function pollTaskStatus(taskId: string): Promise<any> {
     return response.data
   } catch (error: any) {
     console.error('查询任务状态失败:', error)
+    throw new Error(error.response?.data?.detail || error.message || t('api.queryTaskStatusFailed'))
+  }
+}
+
+export async function getTripHistory(limit = 8): Promise<TripHistoryItem[]> {
+  try {
+    const response = await apiClient.get<TripHistoryResponse>('/api/trip/history', {
+      params: { limit },
+    })
+    return Array.isArray(response.data?.items) ? response.data.items : []
+  } catch (error: any) {
+    console.error('查询历史计划失败:', error)
     throw new Error(error.response?.data?.detail || error.message || t('api.queryTaskStatusFailed'))
   }
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -95,6 +95,17 @@ export interface TripPlanResponse {
   graph_data?: KnowledgeGraphData
 }
 
+export interface TripHistoryItem {
+  plan_id: string
+  task_id: string
+  city: string
+  start_date: string
+  end_date: string
+  travel_days: number
+  updated_at: string
+  overall_suggestions?: string
+}
+
 export type TripTaskStatus = 'processing' | 'completed' | 'failed'
 
 export type TripTaskStage =

--- a/frontend/src/views/Landing.vue
+++ b/frontend/src/views/Landing.vue
@@ -228,6 +228,48 @@
         </div>
       </div>
     </section>
+
+    <section class="history-section">
+      <div class="history-panel">
+        <div class="history-head">
+          <div>
+            <p class="history-eyebrow">{{ t('home.history.eyebrow') }}</p>
+            <h3 class="history-title">{{ t('home.history.title') }}</h3>
+          </div>
+          <a-button type="link" class="history-refresh" @click="loadHistoryPlans">
+            {{ t('home.history.refresh') }}
+          </a-button>
+        </div>
+
+        <div v-if="historyLoading" class="history-loading">
+          {{ t('common.loading') }}
+        </div>
+        <a-empty v-else-if="historyPlans.length === 0" :description="t('home.history.empty')" />
+        <div v-else class="history-list">
+          <button
+            v-for="item in historyPlans"
+            :key="item.plan_id"
+            type="button"
+            class="history-item"
+            @click="openHistoryPlan(item.plan_id)"
+          >
+            <div class="history-item-main">
+              <div class="history-route">
+                <span class="history-city">{{ item.city }}</span>
+                <span class="history-date">{{ item.start_date }} {{ t('common.to') }} {{ item.end_date }}</span>
+              </div>
+              <p class="history-meta">
+                <span>Plan ID: {{ item.plan_id }}</span>
+                <span>{{ item.travel_days }}{{ t('home.travelDaysUnit') }}</span>
+                <span>{{ t('home.history.updatedAt') }} {{ formatHistoryTime(item.updated_at) }}</span>
+              </p>
+              <p v-if="item.overall_suggestions" class="history-summary">{{ item.overall_suggestions }}</p>
+            </div>
+            <span class="history-open">{{ t('home.history.open') }}</span>
+          </button>
+        </div>
+      </div>
+    </section>
   </div>
 </template>
 
@@ -236,9 +278,9 @@ import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { message } from 'ant-design-vue'
-import { generateTripPlan } from '@/services/api'
+import { generateTripPlan, getTripHistory } from '@/services/api'
 import NavBar from '@/components/NavBar.vue'
-import type { TripFormData, TripTaskEvent } from '@/types'
+import type { TripFormData, TripTaskEvent, TripHistoryItem } from '@/types'
 import type { Dayjs } from 'dayjs'
 
 type LandingFormData = Omit<TripFormData, 'start_date' | 'end_date'> & {
@@ -258,6 +300,8 @@ const panelRef = ref<HTMLElement | null>(null)
 const panelHeight = ref<number | string>('auto')
 const fogEnabled = ref(true)
 const planCode = ref('')
+const historyLoading = ref(false)
+const historyPlans = ref<TripHistoryItem[]>([])
 
 const getStageStatusText = (stage: TripTaskEvent['stage']) => {
   if (stage === 'submitted' || stage === 'initializing') return t('home.loading.initializing')
@@ -349,9 +393,36 @@ const scrollToForm = () => {
   }
 }
 
+const formatHistoryTime = (value: string) => {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString()
+}
+
+const openHistoryPlan = (planId: string) => {
+  if (!planId) return
+  sessionStorage.removeItem('tripPlan')
+  sessionStorage.removeItem('graphData')
+  sessionStorage.setItem('planId', planId)
+  router.push({ path: '/result', query: { plan_id: planId } })
+}
+
+const loadHistoryPlans = async () => {
+  historyLoading.value = true
+  try {
+    historyPlans.value = await getTripHistory(8)
+  } catch (error: any) {
+    historyPlans.value = []
+    message.error(error.message || t('home.history.loadFailed'))
+  } finally {
+    historyLoading.value = false
+  }
+}
+
 onMounted(() => {
   onScroll()
   window.addEventListener('scroll', onScroll, { passive: true })
+  void loadHistoryPlans()
 })
 onUnmounted(() => {
   window.removeEventListener('scroll', onScroll)
@@ -495,6 +566,129 @@ const handleSubmit = async () => {
   background-position: center center !important;
   overflow: hidden;
   z-index: 1;
+}
+
+.history-section {
+  position: relative;
+  z-index: 1;
+  padding: 0 24px 72px;
+}
+
+.history-panel {
+  max-width: 1120px;
+  margin: 0 auto;
+  background: rgba(10, 20, 28, 0.74);
+  border: 1px solid rgba(203, 227, 255, 0.12);
+  border-radius: 28px;
+  padding: 24px;
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(14px);
+}
+
+.history-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.history-eyebrow {
+  margin: 0 0 6px;
+  color: rgba(203, 227, 255, 0.62);
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.history-title {
+  margin: 0;
+  color: #f5fbff;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.history-refresh {
+  padding-inline: 0;
+}
+
+.history-loading {
+  color: rgba(236, 243, 250, 0.78);
+  padding: 12px 4px;
+}
+
+.history-list {
+  display: grid;
+  gap: 14px;
+}
+
+.history-item {
+  width: 100%;
+  border: 1px solid rgba(203, 227, 255, 0.12);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  padding: 18px 20px;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.history-item:hover {
+  transform: translateY(-1px);
+  border-color: rgba(138, 196, 255, 0.28);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.history-item-main {
+  min-width: 0;
+  flex: 1;
+}
+
+.history-route {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.history-city {
+  color: #f7fbff;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.history-date {
+  color: rgba(236, 243, 250, 0.75);
+  font-size: 14px;
+}
+
+.history-meta {
+  margin: 8px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  color: rgba(203, 227, 255, 0.64);
+  font-size: 13px;
+}
+
+.history-summary {
+  margin: 10px 0 0;
+  color: rgba(236, 243, 250, 0.9);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.history-open {
+  flex: none;
+  color: #8ac4ff;
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .landing-header .content-center {

--- a/frontend/src/views/Result.vue
+++ b/frontend/src/views/Result.vue
@@ -581,10 +581,11 @@ import { EffectCoverflow, Keyboard, Mousewheel } from 'swiper/modules'
 import NavBar from '@/components/NavBar.vue'
 import OverviewAttractionCard from '@/components/OverviewAttractionCard.vue'
 import AIChat from '@/components/AIChat.vue'
-import type { TripPlan, KnowledgeGraphData, GraphCategory, Attraction, Meal, Hotel, WeatherInfo } from '@/types'
+import type { TripPlan, TripPlanResponse, KnowledgeGraphData, GraphCategory, Attraction, Meal, Hotel, WeatherInfo } from '@/types'
 import {
   getRuntimeApiBaseUrl,
   getRuntimeMapJsKey,
+  pollTaskStatus,
   RUNTIME_SETTINGS_UPDATED_EVENT,
 } from '@/services/api'
 
@@ -895,6 +896,47 @@ const graphCategories = ref<GraphCategory[]>([])
 let kgChart: echarts.ECharts | null = null
 let kgResizeHandler: (() => void) | null = null
 
+const applyTripPlanPayload = async (payload: {
+  plan: TripPlan
+  graph?: KnowledgeGraphData | null
+  planId?: string
+}) => {
+  tripPlan.value = payload.plan
+  pendingBudgetItems.value = []
+
+  if (payload.planId) {
+    planId.value = payload.planId
+    sessionStorage.setItem('planId', payload.planId)
+  }
+
+  sessionStorage.setItem('tripPlan', JSON.stringify(payload.plan))
+
+  if (payload.graph) {
+    graphData.value = payload.graph
+    graphCategories.value = payload.graph.categories || []
+    sessionStorage.setItem('graphData', JSON.stringify(payload.graph))
+  } else {
+    graphData.value = null
+    graphCategories.value = []
+    sessionStorage.removeItem('graphData')
+  }
+
+  await loadAttractionPhotos()
+  if (activeSection.value === 'map') await ensureMapReady()
+  if (activeSection.value === 'knowledge-graph') await ensureGraphReady()
+  if (activeSection.value === 'overview') await initOverviewSwiper()
+}
+
+const restoreTripPlanFromResponse = async (response?: TripPlanResponse | null) => {
+  if (!response?.data) return false
+  await applyTripPlanPayload({
+    plan: response.data,
+    graph: response.graph_data || null,
+    planId: String(response.plan_id || planId.value || ''),
+  })
+  return true
+}
+
 const ensureMapReady = async () => {
   await nextTick()
   if (!map) {
@@ -1160,26 +1202,39 @@ onMounted(async () => {
   if (typeof window !== 'undefined') {
     window.addEventListener(RUNTIME_SETTINGS_UPDATED_EVENT, handleRuntimeSettingsUpdated)
   }
-  planId.value = String(route.query.plan_id || sessionStorage.getItem('planId') || '')
+  const storedPlanId = String(sessionStorage.getItem('planId') || '')
+  planId.value = String(route.query.plan_id || storedPlanId || '')
   if (planId.value) {
     sessionStorage.setItem('planId', planId.value)
   }
 
+  const cachedPlanId = storedPlanId
   const data = sessionStorage.getItem('tripPlan')
-  if (data) {
-    tripPlan.value = JSON.parse(data)
-    pendingBudgetItems.value = []
-    // 加载景点图片
-    await loadAttractionPhotos()
-    // 加载知识图谱
+  const canUseCachedData = Boolean(data) && (!planId.value || !cachedPlanId || cachedPlanId === planId.value)
+
+  if (data && canUseCachedData) {
     const gd = sessionStorage.getItem('graphData')
-    if (gd) {
-      graphData.value = JSON.parse(gd)
-      graphCategories.value = graphData.value?.categories || []
+    await applyTripPlanPayload({
+      plan: JSON.parse(data),
+      graph: gd ? JSON.parse(gd) : null,
+      planId: planId.value || cachedPlanId,
+    })
+    return
+  }
+
+  if (planId.value) {
+    try {
+      const task = await pollTaskStatus(planId.value)
+      if (task?.status === 'completed' && task.result) {
+        const restored = await restoreTripPlanFromResponse(task.result)
+        if (restored) return
+      }
+      if (task?.status === 'failed') {
+        message.error(task.error || t('result.noTripPlanDesc'))
+      }
+    } catch (error) {
+      console.error('结果页从后端回补旅行计划失败:', error)
     }
-    if (activeSection.value === 'map') await ensureMapReady()
-    if (activeSection.value === 'knowledge-graph') await ensureGraphReady()
-    if (activeSection.value === 'overview') await initOverviewSwiper()
   }
 })
 


### PR DESCRIPTION
  ## What does this PR do?

  本 PR 主要完成两类改进：

  1. 支持历史计划查询，以及结果页根据 `plan_id` 进行数据回补
  2. 修复仅通过 `.env` 配置时 LLM 环境变量不生效的问题，并增强行程规划阶段的容错能力

  具体包括：

  - 新增旅行计划状态持久化与历史计划查询接口
  - 首页展示最近生成的计划，并支持直接跳转查看
  - 结果页在本地缓存缺失时，可根据 `plan_id` 从后端恢复计划数据
  - 补充历史计划与结果回补相关的多语言文案
  - 兼容读取 `LLM_*` 与 `OPENAI_*` 配置项
  - 在规划阶段增加上下文压缩、超时重试和 MCPTool 展开修正，降低失败率

  ## Why is this change needed?

  当前流程主要有两方面问题：

  1. 历史计划不可追溯
  - 用户刷新页面、本地缓存丢失，或通过链接直接进入结果页时，无法稳定恢复之前生成的计划
  - 首页缺少历史计划入口，已经生成的结果难以再次查看

  2. LLM 运行时配置与规划稳定性不足
  - 在部分部署场景下，如果仅通过 `.env` 配置模型参数，相关环境变量可能无法被正确读取（issue: 实际情况为配置baseurl之后仍然使用openai的baseurl而非自定义url）
  - 当大模型请求超时或辅助上下文信息不完整时，规划流程容易失败

  这次改动的目标是提升用户侧的结果可恢复性，同时提高不同运行环境下的配置兼容性和规划稳定性。

  ## Related Issues

  暂无

  ## Type of Change

  - [x] Feature
  - [x] Bug fix
  - [ ] Documentation
  - [ ] Refactor
  - [ ] Other

  ## Testing
  - 仅通过 `.env` 配置 LLM 相关参数，模型配置能够正确加载
  - 正常生成一条旅行计划，后端已持久化，并可在首页历史计划中看到
  - 清除本地缓存后，携带有效 `plan_id` 打开结果页，确认可以从后端成功恢复数据
  - 检查新增的历史计划与结果页回补相关文案在各语言下显示正常

  ## Screenshots (if applicable)

仅配置`.env`成功显示且后端正常: 
<img width="1215" height="1006" alt="image" src="https://github.com/user-attachments/assets/52d5d4ad-fb19-46c1-91fb-cdceb9b9a015" />

历史记录界面显示: 
<img width="2445" height="1185" alt="image" src="https://github.com/user-attachments/assets/fdd825e2-bf3e-42bb-8e69-6c861f564403" />

个人配置参考：
<img width="1554" height="1130" alt="image" src="https://github.com/user-attachments/assets/430fe011-343b-438a-b37e-4b773c6c6854" />

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] Tests pass locally
  - [ ] Documentation updated (if needed)
  - [x] No breaking changes introduced
