### PR TITLE
feat: add MiniMax-M2.7 as recommended LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ sequenceDiagram
 
 * Python 3.10+
 * Node.js 18+
-* 大模型 API Key（推荐使用兼容 OpenAI 格式的服务商，如豆包）
+* 大模型 API Key（推荐使用兼容 OpenAI 格式的服务商，如豆包、[MiniMax-M2.7](https://platform.minimax.io/docs/api-reference/text-openai-api)）
 * 高德地图两种key： Web服务 、 Web端(JS API) (其**安全密钥 JSCode**配置在index.html中)（[高德api](https://lbs.amap.com/)）
 * [Google Maps API Key](https://developers.google.com/maps/apis-by-platform)（若要使用 Google 地图引擎，必须在 Google Cloud 控制台中开通：**Geocoding API, Places API (New), Directions API, Maps JavaScript API, Weather API**，需要绑卡）
 * 小红书Cookie（[小红书](https://www.xiaohongshu.com/) 网页端登录后从浏览器开发者工具复制）

--- a/README_en.md
+++ b/README_en.md
@@ -138,7 +138,7 @@ The frontend renders dynamic Vue structures recursively by reading JSON data:
 
 * Python 3.10+
 * Node.js 18+
-* Large Model API Key (OpenAI-compatible endpoints highly recommended, e.g., Doubao)
+* Large Model API Key (OpenAI-compatible endpoints highly recommended, e.g., Doubao, [MiniMax-M2.7](https://platform.minimax.io/docs/api-reference/text-openai-api))
 * AMap Keys (Web Service & Web JS API) with **Security JSCode configured in `index.html`** or Google Maps APIs. If using [Google Maps](https://developers.google.com/maps/apis-by-platform), you must enable: **Geocoding API, Places API (New), Directions API, Maps JavaScript API, and Weather API** in Google Cloud Console, and an active billing account is strictly required.
 * Xiaohongshu Cookie (Retrieve from browser dev tools after logging in on Web)
 * The `uv` package manager

--- a/README_ja.md
+++ b/README_ja.md
@@ -50,7 +50,7 @@
 
 * Python 3.10+
 * Node.js 18+
-* 大規模言語モデル API キー（OpenAIと互換性のあるものを推奨。Doubao など）
+* 大規模言語モデル API キー（OpenAIと互換性のあるものを推奨。Doubao、[MiniMax-M2.7](https://platform.minimax.io/docs/api-reference/text-openai-api) など）
 * 高徳マップ (AMap) のキー（Web Service または Web JS API。`index.html` にセキュリティJSCodeの設定が必要）または Google Maps API のキー。Google Mapsを使用する場合、Google Cloudコンソールで **Geocoding API, Places API (New), Directions API, Maps JavaScript API, Weather API** を必ず有効にし、有効な課金アカウント（クレジットカード）をリンクする必要があります。
 * Xiaohongshu の Cookie（ブラウザにログイン後、DevToolsで取得）
 * `uv` パッケージマネージャーのインストール

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,8 +6,13 @@ LLM_MODEL_ID=your-model-name
 # API密钥
 LLM_API_KEY=your-api-key-here
 
-# 服务地址
+# 服务地址（兼容 OpenAI 格式，支持任意第三方服务商）
 LLM_BASE_URL=your-api-base-url
+
+# MiniMax-M2.7 配置示例（高性价比，支持 OpenAI 兼容接口）:
+# LLM_MODEL_ID=MiniMax-M2.7
+# LLM_API_KEY=your-minimax-api-key
+# LLM_BASE_URL=https://api.minimax.io/v1
 
 # 超时时间（可选，默认60秒）
 LLM_TIMEOUT=60


### PR DESCRIPTION
## Summary

- Documents MiniMax-M2.7 as a recommended OpenAI-compatible LLM provider
- Adds a concrete configuration example for MiniMax-M2.7 in backend/.env.example
- Updates README.md, README_en.md, and README_ja.md to mention MiniMax-M2.7

## Why MiniMax-M2.7?

MiniMax-M2.7 supports the OpenAI-compatible API, making it a zero-configuration drop-in. Users only need to set three env vars:

LLM_MODEL_ID=MiniMax-M2.7
LLM_API_KEY=your-minimax-api-key
LLM_BASE_URL=https://api.minimax.io/v1

No code changes are required since the project already uses an OpenAI-compatible client.

## Test plan

- [x] Verified .env.example contains correct MiniMax base URL and model ID
- [x] Verified README changes in all three language variants (zh/en/ja)
- [x] Confirmed MiniMax API is OpenAI-compatible