### PR TITLE
feat: 为行程 Agent 接入 You.com 搜索/研究工具（实时旅行信息）

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ sequenceDiagram
 * 大模型 API Key（推荐使用兼容 OpenAI 格式的服务商，如豆包）
 * 高德地图两种key： Web服务 、 Web端(JS API) (其**安全密钥 JSCode**配置在index.html中)（[高德api](https://lbs.amap.com/)）
 * [Google Maps API Key](https://developers.google.com/maps/apis-by-platform)（若要使用 Google 地图引擎，必须在 Google Cloud 控制台中开通：**Geocoding API, Places API (New), Directions API, Maps JavaScript API, Weather API**，需要绑卡）
+* [You.com API Key](https://you.com/platform/api-keys)（选填，若要启用行程规划 Agent 的联网搜索/深度研究工具，用于补充地图数据之外的实时信息，如活动、开放时间、签证资讯等）
 * 小红书Cookie（[小红书](https://www.xiaohongshu.com/) 网页端登录后从浏览器开发者工具复制）
 * 安装 `uv` 包管理器
 
@@ -210,6 +211,7 @@ cp .env.example .env
 # [必填] VITE_AMAP_WEB_KEY (高德地图 web服务 类型的key)
 # [必填] XHS_COOKIE（小红书网页端登录后的Cookie）
 # [选填] GOOGLE_MAPS_API_KEY, GOOGLE_MAPS_PROXY（如果需要支持 Google 地图引擎）
+# [选填] YOUCOM_API_KEY（如果需要行程规划 Agent 支持 You.com 联网搜索/深度研究）
 
 # 启动 FastAPI (推荐通过 uvicorn)
 uvicorn app.api.main:app --host 0.0.0.0 --port 8000 --reload

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,3 +40,8 @@ GOOGLE_MAPS_API_KEY=
 #   GOOGLE_MAPS_PROXY=http://127.0.0.1:7890
 #   GOOGLE_MAPS_PROXY=socks5://127.0.0.1:1080
 GOOGLE_MAPS_PROXY=
+
+# You.com API 配置 (可选, 填写后行程规划 Agent 额外获得联网搜索/深度研究能力)
+# 用于补充地图数据之外的实时信息: 活动、开放时间、签证/资讯等
+# 从 https://you.com/platform/api-keys 获取
+YOUCOM_API_KEY=

--- a/backend/app/agents/trip_planner_agent.py
+++ b/backend/app/agents/trip_planner_agent.py
@@ -225,7 +225,7 @@ class MultiAgentTripPlanner:
             )
             self.hotel_agent.add_tool(self._active_tool)
 
-            # 创建行程规划Agent(不需要工具)
+            # 创建行程规划Agent(不需要地图工具)
             print("  - 创建行程规划Agent...")
             self.planner_agent = SimpleAgent(
                 name="行程规划专家",
@@ -233,9 +233,15 @@ class MultiAgentTripPlanner:
                 system_prompt=PLANNER_AGENT_PROMPT
             )
 
+            # ---------- 附加 You.com 联网搜索/研究工具 (可选，与地图供应商无关) ----------
+            self._init_youcom_tool(settings)
+            if self._youcom_tool is not None:
+                self.planner_agent.add_tool(self._youcom_tool)
+
             print(f"✅ 多智能体系统初始化成功 (供应商={self.map_provider})")
             print(f"   天气查询Agent: {len(self.weather_agent.list_tools())} 个工具")
             print(f"   酒店推荐Agent: {len(self.hotel_agent.list_tools())} 个工具")
+            print(f"   行程规划Agent: {len(self.planner_agent.list_tools())} 个工具")
 
         except Exception as e:
             print(f"❌ 多智能体系统初始化失败: {str(e)}")
@@ -364,6 +370,116 @@ class MultiAgentTripPlanner:
 
         self._google_tool = GoogleMapsNativeTool()
         self._active_tool = self._google_tool
+
+    def _init_youcom_tool(self, settings) -> None:
+        """初始化 You.com 联网搜索/深度研究本地适配器工具（可选，需配置 youcom_api_key）。
+
+        与地图供应商 (amap/google) 完全独立、可叠加：不修改、不参与地图供应商的
+        判断逻辑 (self.map_provider)。只有配置了 youcom_api_key 时才创建并挂载
+        此工具，未配置时 self._youcom_tool 为 None，行程规划Agent 行为与接入前
+        完全一致。
+        """
+        if not settings.youcom_api_key:
+            self._youcom_tool = None
+            return
+
+        print("  - 创建 You.com 联网搜索/研究工具...")
+        from ..services.youcom_service import YoucomService
+
+        youcom_svc = YoucomService(api_key=settings.youcom_api_key)
+
+        class YoucomNativeTool:
+            """将 You.com Search/Research API 封装为 hello_agents 可注册的工具。
+
+            通过鸭子类型模拟 MCPTool 的接口（name, description, expandable,
+            _available_tools, run），无需继承任何基类，与 GoogleMapsNativeTool
+            的实现模式保持一致。
+
+            注册后在 Agent 的可用工具列表中暴露为:
+              - youcom_web_search
+              - youcom_research
+            """
+
+            def __init__(self):
+                self.name = "youcom"
+                self.description = "You.com 联网搜索/深度研究服务 (地图数据之外的实时信息)"
+                self.expandable = True
+                self._youcom_svc = youcom_svc
+                # 模拟 MCP 子工具列表，使 hello_agents 能自动展开
+                self._available_tools = [
+                    {
+                        "name": "youcom_web_search",
+                        "description": "You.com 实时联网搜索（活动/开放时间/签证/资讯等地图数据之外的实时信息）",
+                    },
+                    {
+                        "name": "youcom_research",
+                        "description": "You.com 深度研究（复杂行程/多来源综合，附引用）",
+                    },
+                ]
+
+            def get_expanded_tools(self):
+                """返回展开的子工具列表，满足 hello_agents ToolRegistry 的接口要求。"""
+                parent = self
+
+                class _SubTool:
+                    def __init__(self, name, description):
+                        self.name = name
+                        self.description = description
+                        self.expandable = False
+
+                    def run(self, input_data):
+                        return parent.run(input_data)
+
+                    def get_expanded_tools(self):
+                        return [self]
+
+                return [_SubTool(t["name"], t["description"]) for t in self._available_tools]
+
+            def run(self, input_data):
+                """分发 [TOOL_CALL:youcom_*:...] 格式调用。"""
+                import re as _re
+                if isinstance(input_data, dict):
+                    tool_name = input_data.get("tool_name", "")
+                    arguments = input_data.get("arguments", {})
+                elif isinstance(input_data, str):
+                    # 解析 [TOOL_CALL:youcom_xxx:key=val,...] 格式
+                    match = _re.search(
+                        r'\[TOOL_CALL:(\w+):(.*?)\]', input_data
+                    )
+                    if match:
+                        tool_name = match.group(1)
+                        args_str = match.group(2)
+                        arguments = dict(
+                            kv.split("=", 1)
+                            for kv in args_str.split(",")
+                            if "=" in kv
+                        )
+                    else:
+                        return f"无法解析工具调用: {input_data}"
+                else:
+                    return f"不支持的输入类型: {type(input_data)}"
+
+                return self._dispatch(tool_name, arguments)
+
+            def _dispatch(self, tool_name: str, arguments: dict) -> str:
+                try:
+                    if tool_name == "youcom_web_search":
+                        query = arguments.get("query", "")
+                        count = arguments.get("count", 5)
+                        freshness = arguments.get("freshness") or None
+                        country = arguments.get("country") or None
+                        return self._youcom_svc.search(
+                            query, count=count, freshness=freshness, country=country
+                        )
+                    elif tool_name == "youcom_research":
+                        query = arguments.get("query", "")
+                        return self._youcom_svc.research(query)
+                    else:
+                        return f"未知的 You.com 工具: {tool_name}"
+                except Exception as e:
+                    return f"You.com 工具调用失败: {e}"
+
+        self._youcom_tool = YoucomNativeTool()
 
     async def _emit_progress(
         self,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -41,6 +41,9 @@ class Settings(BaseSettings):
     google_maps_api_key: str = ""
     google_maps_proxy: str = ""
 
+    # You.com API配置 (可选, 用于联网搜索/深度研究工具)
+    youcom_api_key: str = ""
+
     # 小红书配置
     xhs_cookie: str = ""
 
@@ -79,6 +82,7 @@ _RUNTIME_SETTING_KEYS = {
     "vite_amap_web_js_key",
     "google_maps_api_key",
     "google_maps_proxy",
+    "youcom_api_key",
     "xhs_cookie",
     "openai_api_key",
     "openai_base_url",
@@ -144,6 +148,7 @@ def get_runtime_settings() -> Dict[str, str]:
         "vite_amap_web_js_key": settings.vite_amap_web_js_key or "",
         "google_maps_api_key": settings.google_maps_api_key or "",
         "google_maps_proxy": settings.google_maps_proxy or "",
+        "youcom_api_key": settings.youcom_api_key or "",
         "xhs_cookie": settings.xhs_cookie or "",
         "openai_api_key": settings.openai_api_key or "",
         "openai_base_url": settings.openai_base_url or "",
@@ -197,6 +202,7 @@ def print_config():
     print(f"高德地图JS Key: {'已配置' if settings.vite_amap_web_js_key else '未配置'}")
     print(f"Google Maps API Key: {'已配置' if settings.google_maps_api_key else '未配置'}")
     print(f"Google Maps Proxy: {settings.google_maps_proxy or '未配置'}")
+    print(f"You.com API Key: {'已配置' if settings.youcom_api_key else '未配置'}")
     print(f"小红书Cookie: {'已配置' if settings.xhs_cookie else '未配置'}")
 
     # 检查LLM配置

--- a/backend/app/services/youcom_service.py
+++ b/backend/app/services/youcom_service.py
@@ -1,0 +1,285 @@
+"""You.com 联网搜索 / 深度研究服务封装
+
+提供两个能力，作为地图数据（高德/Google）之外的"实时联网信息"补充:
+  - search   → You.com Search API   (https://ydc-index.io/v1/search)
+  - research → You.com Research API (https://api.you.com/v1/research)
+
+设计要求（保证可在不安装 hello_agents / 不启动完整应用的情况下被单元测试）:
+  - 只依赖 httpx，不依赖 config / hello_agents / 应用其它模块。
+  - 任何异常路径都不抛出未捕获异常，只返回清晰的中文提示字符串。
+  - 任何返回值都绝不包含 API Key 原文（即便发生异常）。
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+
+
+class YoucomService:
+    """You.com 联网搜索 / 深度研究服务封装类"""
+
+    SEARCH_URL = "https://ydc-index.io/v1/search"
+    RESEARCH_URL = "https://api.you.com/v1/research"
+
+    DEFAULT_COUNT = 5
+    MAX_COUNT = 20
+    DEFAULT_TIMEOUT = 15.0
+
+    def __init__(self, api_key: str, timeout: float = DEFAULT_TIMEOUT):
+        self.api_key = api_key or ""
+        self._client = httpx.Client(timeout=timeout)
+
+    def close(self) -> None:
+        """关闭 HTTP 客户端连接池。"""
+        self._client.close()
+
+    # ======================== 联网搜索 ========================
+
+    def search(
+        self,
+        query: Any,
+        count: Any = DEFAULT_COUNT,
+        freshness: Optional[str] = None,
+        country: Optional[str] = None,
+    ) -> str:
+        """You.com 实时联网搜索。
+
+        Args:
+            query: 搜索关键词
+            count: 返回结果条数（默认 5，最大 20，非法值回退默认值）
+            freshness: 时间范围过滤（可选，原样透传给 API）
+            country: 国家/地区过滤（可选，原样透传给 API）
+
+        Returns:
+            供 Agent 阅读的编号结构化文本；出错或未配置 Key 时返回清晰提示，绝不抛出异常。
+        """
+        if not self.api_key:
+            return "未配置 You.com API Key，无法使用联网搜索"
+
+        q = self._normalize_query(query)
+        if not q:
+            return "搜索关键词不能为空"
+
+        params: Dict[str, Any] = {
+            "query": q,
+            "count": self._normalize_count(count),
+        }
+        if freshness:
+            params["freshness"] = freshness
+        if country:
+            params["country"] = country
+
+        data, err = self._call(
+            "GET",
+            self.SEARCH_URL,
+            "搜索",
+            headers={"X-API-Key": self.api_key},
+            params=params,
+        )
+        if err:
+            return self._scrub(err)
+        return self._scrub(self._format_search_result(data))
+
+    # ======================== 深度研究 ========================
+
+    def research(self, query: Any) -> str:
+        """You.com 深度研究（复杂行程/多来源综合，附引用）。
+
+        Args:
+            query: 研究主题/问题
+
+        Returns:
+            研究结论 + 编号引用来源；出错或未配置 Key 时返回清晰提示，绝不抛出异常。
+        """
+        if not self.api_key:
+            return "未配置 You.com API Key，无法使用深度研究"
+
+        q = self._normalize_query(query)
+        if not q:
+            return "研究主题不能为空"
+
+        body = {"input": q, "research_effort": "lite"}
+
+        data, err = self._call(
+            "POST",
+            self.RESEARCH_URL,
+            "深度研究",
+            headers={"X-API-Key": self.api_key},
+            json=body,
+        )
+        if err:
+            return self._scrub(err)
+        return self._scrub(self._format_research_result(data))
+
+    # ======================== 内部工具 ========================
+
+    def _call(
+        self, method: str, url: str, label: str, **kwargs: Any
+    ) -> Tuple[Optional[Any], Optional[str]]:
+        """执行一次 HTTP 请求，返回 (data, error_message)，永不抛出异常。"""
+        try:
+            if method == "GET":
+                resp = self._client.get(url, **kwargs)
+            else:
+                resp = self._client.post(url, **kwargs)
+            resp.raise_for_status()
+            data = resp.json()
+            return data, None
+        except httpx.TimeoutException:
+            return None, f"You.com {label}请求超时，请稍后重试"
+        except httpx.HTTPStatusError as e:
+            status_code = e.response.status_code if e.response is not None else 0
+            return None, self._map_http_error(status_code, label)
+        except httpx.RequestError as e:
+            return None, f"You.com {label}网络请求失败: {type(e).__name__}"
+        except ValueError:
+            # 含 json.JSONDecodeError（响应体不是合法 JSON 或为空）
+            return None, f"You.com {label}返回数据解析失败"
+        except Exception as e:
+            return None, f"You.com {label}调用异常: {type(e).__name__}"
+
+    @staticmethod
+    def _map_http_error(status_code: int, label: str) -> str:
+        mapping = {
+            401: "You.com API Key 无效或已过期",
+            403: "You.com 请求被拒绝，请检查请求地址或权限",
+            422: "You.com 请求参数有误",
+            429: "You.com 请求过于频繁，请稍后重试",
+        }
+        if status_code in mapping:
+            return f"You.com {label}失败: {mapping[status_code]} ({status_code})"
+        if 500 <= status_code < 600:
+            return f"You.com {label}失败: 服务暂时不可用 ({status_code})，请稍后重试"
+        return f"You.com {label}失败: 返回错误状态码 {status_code}"
+
+    @staticmethod
+    def _normalize_query(query: Any) -> str:
+        if query is None:
+            return ""
+        if not isinstance(query, str):
+            try:
+                query = str(query)
+            except Exception:
+                return ""
+        return query.strip()
+
+    @classmethod
+    def _normalize_count(cls, count: Any) -> int:
+        try:
+            n = int(count)
+        except (TypeError, ValueError):
+            return cls.DEFAULT_COUNT
+        if n <= 0:
+            return cls.DEFAULT_COUNT
+        if n > cls.MAX_COUNT:
+            return cls.MAX_COUNT
+        return n
+
+    def _scrub(self, text: str) -> str:
+        """兜底防护：确保返回文本中绝不出现 API Key 原文。"""
+        if self.api_key and text and self.api_key in text:
+            return text.replace(self.api_key, "[REDACTED]")
+        return text
+
+    @staticmethod
+    def _format_item(idx: int, item: Any) -> str:
+        if not isinstance(item, dict):
+            return ""
+        title = (item.get("title") or "").strip() if isinstance(item.get("title"), str) else ""
+        url = (item.get("url") or "").strip() if isinstance(item.get("url"), str) else ""
+        description = (
+            (item.get("description") or "").strip()
+            if isinstance(item.get("description"), str)
+            else ""
+        )
+        raw_snippets = item.get("snippets")
+        snippets: List[str] = raw_snippets if isinstance(raw_snippets, list) else []
+        clean_snippets = [s.strip() for s in snippets if isinstance(s, str) and s.strip()]
+
+        if not title and not url and not description and not clean_snippets:
+            return ""
+
+        lines = [f"{idx}. {title or '(无标题)'}"]
+        if url:
+            lines.append(f"   链接: {url}")
+        if description:
+            lines.append(f"   简介: {description}")
+        for s in clean_snippets:
+            lines.append(f"   摘要: {s}")
+        return "\n".join(lines)
+
+    @classmethod
+    def _format_search_result(cls, data: Any) -> str:
+        if not isinstance(data, dict):
+            return "未找到相关信息"
+
+        results = data.get("results")
+        if not isinstance(results, dict):
+            results = {}
+
+        raw_web = results.get("web")
+        web: List[Any] = raw_web if isinstance(raw_web, list) else []
+        raw_news = results.get("news")
+        news: List[Any] = raw_news if isinstance(raw_news, list) else []
+
+        blocks: List[str] = []
+        idx = 1
+        for item in web:
+            block = cls._format_item(idx, item)
+            if block:
+                blocks.append(block)
+                idx += 1
+
+        if news:
+            news_blocks: List[str] = []
+            for item in news:
+                block = cls._format_item(idx, item)
+                if block:
+                    news_blocks.append(block)
+                    idx += 1
+            if news_blocks:
+                blocks.append("相关资讯:")
+                blocks.extend(news_blocks)
+
+        if not blocks:
+            return "未找到相关信息"
+        return "\n".join(blocks)
+
+    @staticmethod
+    def _format_research_result(data: Any) -> str:
+        if not isinstance(data, dict):
+            return "未获取到研究结果"
+
+        output = data.get("output")
+        content = ""
+        sources: List[Any] = []
+        if isinstance(output, dict):
+            raw_content = output.get("content")
+            content = raw_content.strip() if isinstance(raw_content, str) else ""
+            raw_sources = output.get("sources")
+            sources = raw_sources if isinstance(raw_sources, list) else []
+
+        lines: List[str] = [content if content else "未获取到研究内容"]
+
+        valid_sources: List[Tuple[str, str]] = []
+        for s in sources:
+            if isinstance(s, dict):
+                url = s.get("url") if isinstance(s.get("url"), str) else ""
+                title = s.get("title") if isinstance(s.get("title"), str) else ""
+                url = url.strip()
+                title = title.strip()
+                if url or title:
+                    valid_sources.append((title, url))
+            elif isinstance(s, str) and s.strip():
+                valid_sources.append(("", s.strip()))
+
+        if valid_sources:
+            lines.append("")
+            lines.append("参考来源:")
+            for i, (title, url) in enumerate(valid_sources, start=1):
+                if title and url:
+                    lines.append(f"{i}. {title} - {url}")
+                else:
+                    lines.append(f"{i}. {title or url}")
+
+        return "\n".join(lines)

--- a/backend/tests/test_youcom_agent_wrapper.py
+++ b/backend/tests/test_youcom_agent_wrapper.py
@@ -1,0 +1,135 @@
+"""针对 trip_planner_agent.py 中 You.com 工具包装器 (YoucomNativeTool) 的测试。
+
+这是"锦上添花"的补充测试：验证 [TOOL_CALL:youcom_*:...] 解析 -> 分发 -> 调用
+YoucomService 的链路是否与 GoogleMapsNativeTool 的既有模式完全一致。
+
+注意: trip_planner_agent.py 顶层 import 了 hello_agents（以及 huggingface_hub
+等其依赖）。本测试文件因此需要这些包已安装，不属于 youcom_service 本身的最小
+测试基线（test_youcom_service.py 完全不依赖它们）。如果 hello_agents 在某个
+环境里装不上，这层覆盖会跳过，只用现场 e2e 脚本验证包装器行为即可（已在
+logfile 中记录该取舍）。
+
+不会真正初始化 MultiAgentTripPlanner（会尝试拉起高德/Google 的地图工具，
+涉及子进程与外部依赖）；而是直接对 `_init_youcom_tool` 这个未绑定方法调用，
+传入一个"裸"占位 self 对象，只验证 You.com 工具本身的行为，不触碰
+amap/google 供应商选择逻辑。
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+try:
+    from backend.app.agents.trip_planner_agent import MultiAgentTripPlanner
+    HELLO_AGENTS_AVAILABLE = True
+    IMPORT_ERROR = None
+except Exception as e:  # pragma: no cover - environment-dependent skip
+    MultiAgentTripPlanner = None
+    HELLO_AGENTS_AVAILABLE = False
+    IMPORT_ERROR = e
+
+
+class _BareSelf:
+    """占位对象：只需要能承载 self._youcom_tool 属性即可。"""
+    pass
+
+
+@unittest.skipUnless(
+    HELLO_AGENTS_AVAILABLE,
+    f"hello_agents 及其依赖未安装，跳过 YoucomNativeTool 包装器测试: {IMPORT_ERROR}",
+)
+class TestYoucomToolRegistrationGuard(unittest.TestCase):
+    def test_no_key_leaves_tool_none(self):
+        settings = MagicMock(youcom_api_key="")
+        fake = _BareSelf()
+        MultiAgentTripPlanner._init_youcom_tool(fake, settings)
+        self.assertIsNone(fake._youcom_tool)
+
+    def test_key_present_creates_tool_with_expected_shape(self):
+        settings = MagicMock(youcom_api_key="fake-key-for-wrapper-test")
+        fake = _BareSelf()
+        with patch(
+            "backend.app.services.youcom_service.YoucomService"
+        ) as MockSvc:
+            MockSvc.return_value = MagicMock()
+            MultiAgentTripPlanner._init_youcom_tool(fake, settings)
+            MockSvc.assert_called_once_with(api_key="fake-key-for-wrapper-test")
+
+        tool = fake._youcom_tool
+        self.assertIsNotNone(tool)
+        self.assertEqual(tool.name, "youcom")
+        self.assertTrue(tool.expandable)
+        names = [t["name"] for t in tool._available_tools]
+        self.assertEqual(names, ["youcom_web_search", "youcom_research"])
+
+
+@unittest.skipUnless(
+    HELLO_AGENTS_AVAILABLE,
+    f"hello_agents 及其依赖未安装，跳过 YoucomNativeTool 包装器测试: {IMPORT_ERROR}",
+)
+class TestYoucomToolDispatch(unittest.TestCase):
+    def setUp(self):
+        settings = MagicMock(youcom_api_key="fake-key")
+        fake = _BareSelf()
+        with patch(
+            "backend.app.services.youcom_service.YoucomService"
+        ) as MockSvc:
+            self.mock_svc_instance = MagicMock()
+            MockSvc.return_value = self.mock_svc_instance
+            MultiAgentTripPlanner._init_youcom_tool(fake, settings)
+        self.tool = fake._youcom_tool
+
+    def test_run_parses_tool_call_string_and_routes_to_search(self):
+        self.mock_svc_instance.search.return_value = "搜索结果文本"
+        out = self.tool.run("[TOOL_CALL:youcom_web_search:query=东京樱花,count=3]")
+        self.assertEqual(out, "搜索结果文本")
+        self.mock_svc_instance.search.assert_called_once()
+        _, kwargs = self.mock_svc_instance.search.call_args
+        self.assertEqual(kwargs.get("count"), "3")
+
+    def test_run_parses_tool_call_string_and_routes_to_research(self):
+        self.mock_svc_instance.research.return_value = "研究结果文本"
+        out = self.tool.run("[TOOL_CALL:youcom_research:query=多城市行程规划建议]")
+        self.assertEqual(out, "研究结果文本")
+        self.mock_svc_instance.research.assert_called_once_with("多城市行程规划建议")
+
+    def test_run_with_dict_input(self):
+        self.mock_svc_instance.search.return_value = "字典输入结果"
+        out = self.tool.run({
+            "tool_name": "youcom_web_search",
+            "arguments": {"query": "签证要求"},
+        })
+        self.assertEqual(out, "字典输入结果")
+
+    def test_run_unparsable_string_returns_error_no_crash(self):
+        out = self.tool.run("not a tool call at all")
+        self.assertIn("无法解析工具调用", out)
+        self.mock_svc_instance.search.assert_not_called()
+        self.mock_svc_instance.research.assert_not_called()
+
+    def test_run_unsupported_input_type_no_crash(self):
+        out = self.tool.run(12345)
+        self.assertIn("不支持的输入类型", out)
+
+    def test_dispatch_unknown_tool_name(self):
+        out = self.tool._dispatch("youcom_unknown_tool", {})
+        self.assertIn("未知的 You.com 工具", out)
+
+    def test_dispatch_swallows_service_exception(self):
+        self.mock_svc_instance.search.side_effect = RuntimeError("boom")
+        out = self.tool._dispatch("youcom_web_search", {"query": "q"})
+        self.assertIn("You.com 工具调用失败", out)
+
+    def test_get_expanded_tools_returns_two_subtools_that_delegate(self):
+        self.mock_svc_instance.search.return_value = "子工具搜索结果"
+        subtools = self.tool.get_expanded_tools()
+        self.assertEqual(len(subtools), 2)
+        sub_names = {t.name for t in subtools}
+        self.assertEqual(sub_names, {"youcom_web_search", "youcom_research"})
+        web_search_subtool = next(t for t in subtools if t.name == "youcom_web_search")
+        self.assertFalse(web_search_subtool.expandable)
+        out = web_search_subtool.run("[TOOL_CALL:youcom_web_search:query=q]")
+        self.assertEqual(out, "子工具搜索结果")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_youcom_service.py
+++ b/backend/tests/test_youcom_service.py
@@ -1,0 +1,543 @@
+"""深度单元测试：backend.app.services.youcom_service.YoucomService
+
+设计要点：
+  - 完全离线：使用 unittest.mock 替换 YoucomService._client 的 get/post 方法，
+    不发起任何真实网络请求。
+  - 不 import hello_agents / config / 完整应用，服务模块本身也不依赖它们。
+  - 覆盖：请求构造、响应映射、每一种错误路径、对抗性输入，并在所有场景下
+    断言 API Key 原文绝不会出现在任何返回值中。
+
+运行方式:
+  python3 -m unittest backend.tests.test_youcom_service -v
+  (或 python3 -m unittest discover -s backend/tests -v，需将仓库根目录加入 PYTHONPATH)
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock
+
+import httpx
+
+from backend.app.services.youcom_service import YoucomService
+
+
+SECRET_KEY = "ydc-super-secret-key-1234567890"
+
+
+def make_response(json_data=None, status_code=200, json_raises=None):
+    """构造一个可用于替换 httpx 响应对象的 MagicMock。"""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.raise_for_status.return_value = None
+    if json_raises is not None:
+        resp.json.side_effect = json_raises
+    else:
+        resp.json.return_value = json_data
+    return resp
+
+
+def make_http_status_error(status_code, message="http error"):
+    resp = MagicMock()
+    resp.status_code = status_code
+    exc = httpx.HTTPStatusError(message, request=MagicMock(), response=resp)
+    resp.raise_for_status.side_effect = exc
+    return resp
+
+
+class YoucomServiceTestCase(unittest.TestCase):
+    """公共 setUp：构造一个带假 client 的服务实例。"""
+
+    def setUp(self):
+        self.svc = YoucomService(api_key=SECRET_KEY)
+        # 用 Mock 替换真实的 httpx.Client 实例方法，杜绝任何网络调用
+        self.svc._client.get = MagicMock()
+        self.svc._client.post = MagicMock()
+
+    def assertKeyNotLeaked(self, text):
+        self.assertNotIn(SECRET_KEY, text)
+
+
+# =====================================================================
+# 1. search() 请求构造
+# =====================================================================
+class TestSearchRequestConstruction(YoucomServiceTestCase):
+    def test_url_and_header(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("东京 樱花")
+        args, kwargs = self.svc._client.get.call_args
+        self.assertEqual(args[0], YoucomService.SEARCH_URL)
+        self.assertEqual(kwargs["headers"]["X-API-Key"], SECRET_KEY)
+
+    def test_query_param_passed(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("最佳旅行时间")
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["query"], "最佳旅行时间")
+
+    def test_default_count(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("q")
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["count"], 5)
+
+    def test_custom_count(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("q", count=10)
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["count"], 10)
+
+    def test_count_capped_at_20(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("q", count=999)
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["count"], 20)
+
+    def test_count_exactly_20_not_capped_down(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("q", count=20)
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["count"], 20)
+
+    def test_count_zero_falls_back_to_default(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("q", count=0)
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["count"], 5)
+
+    def test_count_negative_falls_back_to_default(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("q", count=-3)
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["count"], 5)
+
+    def test_count_non_numeric_string_falls_back_to_default(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("q", count="abc")
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["count"], 5)
+
+    def test_count_none_falls_back_to_default(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("q", count=None)
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["count"], 5)
+
+    def test_count_numeric_string_is_accepted(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("q", count="7")
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["count"], 7)
+
+    def test_count_float_truncated(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("q", count=3.9)
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["count"], 3)
+
+    def test_freshness_and_country_passthrough(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("q", freshness="pastDay", country="CN")
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["freshness"], "pastDay")
+        self.assertEqual(kwargs["params"]["country"], "CN")
+
+    def test_freshness_and_country_absent_by_default(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        self.svc.search("q")
+        _, kwargs = self.svc._client.get.call_args
+        self.assertNotIn("freshness", kwargs["params"])
+        self.assertNotIn("country", kwargs["params"])
+
+
+# =====================================================================
+# 2. search() 响应映射
+# =====================================================================
+class TestSearchResponseMapping(YoucomServiceTestCase):
+    def test_web_present_numbered_fields(self):
+        self.svc._client.get.return_value = make_response({
+            "results": {
+                "web": [
+                    {
+                        "title": "东京樱花攻略",
+                        "url": "https://example.com/a",
+                        "description": "详细攻略",
+                        "snippets": ["3月下旬最佳", "上野公园推荐"],
+                    }
+                ]
+            }
+        })
+        out = self.svc.search("q")
+        self.assertIn("1. 东京樱花攻略", out)
+        self.assertIn("链接: https://example.com/a", out)
+        self.assertIn("简介: 详细攻略", out)
+        self.assertIn("摘要: 3月下旬最佳", out)
+        self.assertIn("摘要: 上野公园推荐", out)
+
+    def test_news_present_after_web_with_divider(self):
+        self.svc._client.get.return_value = make_response({
+            "results": {
+                "web": [{"title": "A", "url": "u1", "description": "d1", "snippets": []}],
+                "news": [{"title": "B", "url": "u2", "description": "d2", "snippets": []}],
+            }
+        })
+        out = self.svc.search("q")
+        self.assertIn("1. A", out)
+        self.assertIn("相关资讯:", out)
+        self.assertIn("2. B", out)
+        # 相关资讯必须出现在 web 之后
+        self.assertLess(out.index("1. A"), out.index("相关资讯:"))
+        self.assertLess(out.index("相关资讯:"), out.index("2. B"))
+
+    def test_both_web_and_news_absent(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        out = self.svc.search("q")
+        self.assertEqual(out, "未找到相关信息")
+
+    def test_missing_title_shows_placeholder(self):
+        self.svc._client.get.return_value = make_response({
+            "results": {"web": [{"url": "u1", "description": "d1"}]}
+        })
+        out = self.svc.search("q")
+        self.assertIn("1. (无标题)", out)
+
+    def test_missing_url_omits_link_line(self):
+        self.svc._client.get.return_value = make_response({
+            "results": {"web": [{"title": "T", "description": "d1"}]}
+        })
+        out = self.svc.search("q")
+        self.assertNotIn("链接:", out)
+
+    def test_missing_description_omits_line(self):
+        self.svc._client.get.return_value = make_response({
+            "results": {"web": [{"title": "T", "url": "u1"}]}
+        })
+        out = self.svc.search("q")
+        self.assertNotIn("简介:", out)
+
+    def test_blank_and_empty_snippets_filtered(self):
+        self.svc._client.get.return_value = make_response({
+            "results": {
+                "web": [
+                    {"title": "T", "url": "u1", "snippets": ["", "   ", "真实摘要", None, 123]}
+                ]
+            }
+        })
+        out = self.svc.search("q")
+        self.assertIn("摘要: 真实摘要", out)
+        self.assertEqual(out.count("摘要:"), 1)
+
+    def test_results_null(self):
+        self.svc._client.get.return_value = make_response({"results": None})
+        out = self.svc.search("q")
+        self.assertEqual(out, "未找到相关信息")
+
+    def test_web_null_defensive(self):
+        self.svc._client.get.return_value = make_response({"results": {"web": None, "news": None}})
+        out = self.svc.search("q")
+        self.assertEqual(out, "未找到相关信息")
+
+    def test_web_null_but_news_present(self):
+        self.svc._client.get.return_value = make_response({
+            "results": {"web": None, "news": [{"title": "N", "url": "u"}]}
+        })
+        out = self.svc.search("q")
+        self.assertIn("1. N", out)
+
+    def test_data_not_dict(self):
+        self.svc._client.get.return_value = make_response("not-a-dict")
+        out = self.svc.search("q")
+        self.assertEqual(out, "未找到相关信息")
+
+    def test_non_dict_items_in_list_are_skipped_without_crash(self):
+        self.svc._client.get.return_value = make_response({
+            "results": {"web": [{"title": "Good", "url": "u"}, "garbage", None, 42]}
+        })
+        out = self.svc.search("q")
+        self.assertIn("1. Good", out)
+        # 只有一条有效结果，编号不应跳到 2
+        self.assertNotIn("2.", out)
+
+    def test_unicode_preserved(self):
+        self.svc._client.get.return_value = make_response({
+            "results": {"web": [{"title": "东京🌸花见 2026", "url": "u", "description": "签证/护照信息"}]}
+        })
+        out = self.svc.search("q")
+        self.assertIn("东京🌸花见 2026", out)
+        self.assertIn("签证/护照信息", out)
+
+    def test_empty_web_list(self):
+        self.svc._client.get.return_value = make_response({"results": {"web": []}})
+        out = self.svc.search("q")
+        self.assertEqual(out, "未找到相关信息")
+
+
+# =====================================================================
+# 3. search() 错误路径
+# =====================================================================
+class TestSearchErrors(YoucomServiceTestCase):
+    def test_missing_key_returns_clean_message_and_does_not_call_network(self):
+        svc = YoucomService(api_key="")
+        svc._client.get = MagicMock()
+        out = svc.search("q")
+        self.assertIn("未配置 You.com API Key", out)
+        svc._client.get.assert_not_called()
+
+    def _assert_status_error(self, status_code):
+        self.svc._client.get.return_value = make_http_status_error(status_code)
+        out = self.svc.search("q")
+        self.assertIn(str(status_code), out)
+        self.assertKeyNotLeaked(out)
+        return out
+
+    def test_401_unauthorized(self):
+        out = self._assert_status_error(401)
+        self.assertIn("失败", out)
+
+    def test_403_forbidden(self):
+        self._assert_status_error(403)
+
+    def test_422_bad_params(self):
+        self._assert_status_error(422)
+
+    def test_429_rate_limited(self):
+        self._assert_status_error(429)
+
+    def test_500_server_error(self):
+        self._assert_status_error(500)
+
+    def test_503_server_error(self):
+        self._assert_status_error(503)
+
+    def test_timeout(self):
+        self.svc._client.get.side_effect = httpx.TimeoutException("timed out")
+        out = self.svc.search("q")
+        self.assertIn("超时", out)
+        self.assertKeyNotLeaked(out)
+
+    def test_malformed_json(self):
+        self.svc._client.get.return_value = make_response(
+            json_raises=json.JSONDecodeError("Expecting value", "doc", 0)
+        )
+        out = self.svc.search("q")
+        self.assertIn("解析失败", out)
+        self.assertKeyNotLeaked(out)
+
+    def test_empty_body(self):
+        # 空响应体典型表现为 json() 抛出 JSONDecodeError
+        self.svc._client.get.return_value = make_response(
+            json_raises=json.JSONDecodeError("Expecting value", "", 0)
+        )
+        out = self.svc.search("q")
+        self.assertIsInstance(out, str)
+        self.assertTrue(out)
+        self.assertKeyNotLeaked(out)
+
+    def test_generic_connection_error_no_crash(self):
+        self.svc._client.get.side_effect = httpx.ConnectError("dns failure")
+        out = self.svc.search("q")
+        self.assertIn("网络请求失败", out)
+        self.assertKeyNotLeaked(out)
+
+    def test_unexpected_exception_no_crash(self):
+        self.svc._client.get.side_effect = RuntimeError("boom")
+        out = self.svc.search("q")
+        self.assertIsInstance(out, str)
+        self.assertKeyNotLeaked(out)
+
+    def test_key_never_leaked_even_if_exception_message_contains_it(self):
+        # 极端情况：异常消息本身意外包含了 key（例如第三方库回显了请求参数）
+        self.svc._client.get.side_effect = RuntimeError(f"failed with key {SECRET_KEY}")
+        out = self.svc.search("q")
+        self.assertKeyNotLeaked(out)
+
+
+# =====================================================================
+# 4. research() 请求构造
+# =====================================================================
+class TestResearchRequestConstruction(YoucomServiceTestCase):
+    def test_url_and_header(self):
+        self.svc._client.post.return_value = make_response({"output": {"content": "c"}})
+        self.svc.research("规划东京五日游")
+        args, kwargs = self.svc._client.post.call_args
+        self.assertEqual(args[0], YoucomService.RESEARCH_URL)
+        self.assertEqual(kwargs["headers"]["X-API-Key"], SECRET_KEY)
+
+    def test_request_body(self):
+        self.svc._client.post.return_value = make_response({"output": {"content": "c"}})
+        self.svc.research("规划东京五日游")
+        _, kwargs = self.svc._client.post.call_args
+        self.assertEqual(kwargs["json"]["input"], "规划东京五日游")
+        self.assertEqual(kwargs["json"]["research_effort"], "lite")
+
+
+# =====================================================================
+# 5. research() 响应映射
+# =====================================================================
+class TestResearchResponseMapping(YoucomServiceTestCase):
+    def test_content_and_sources(self):
+        self.svc._client.post.return_value = make_response({
+            "output": {
+                "content": "东京樱花季建议3月下旬到访。",
+                "sources": [
+                    {"title": "官方旅游局", "url": "https://a.example"},
+                    {"title": "", "url": "https://b.example"},
+                ],
+            }
+        })
+        out = self.svc.research("q")
+        self.assertIn("东京樱花季建议3月下旬到访。", out)
+        self.assertIn("参考来源:", out)
+        self.assertIn("1. 官方旅游局 - https://a.example", out)
+        self.assertIn("2. https://b.example", out)
+
+    def test_sources_as_plain_strings(self):
+        self.svc._client.post.return_value = make_response({
+            "output": {"content": "内容", "sources": ["https://a", "https://b"]}
+        })
+        out = self.svc.research("q")
+        self.assertIn("1. https://a", out)
+        self.assertIn("2. https://b", out)
+
+    def test_missing_content(self):
+        self.svc._client.post.return_value = make_response({"output": {"sources": []}})
+        out = self.svc.research("q")
+        self.assertIn("未获取到研究内容", out)
+
+    def test_missing_output(self):
+        self.svc._client.post.return_value = make_response({})
+        out = self.svc.research("q")
+        self.assertIn("未获取到研究内容", out)
+        self.assertNotIn("参考来源", out)
+
+    def test_data_not_dict(self):
+        self.svc._client.post.return_value = make_response(None)
+        out = self.svc.research("q")
+        self.assertEqual(out, "未获取到研究结果")
+
+    def test_source_missing_url_uses_title_only(self):
+        self.svc._client.post.return_value = make_response({
+            "output": {"content": "c", "sources": [{"title": "仅标题"}]}
+        })
+        out = self.svc.research("q")
+        self.assertIn("1. 仅标题", out)
+
+    def test_bad_sources_entries_skipped(self):
+        self.svc._client.post.return_value = make_response({
+            "output": {"content": "c", "sources": [{}, None, 42, ""]}
+        })
+        out = self.svc.research("q")
+        self.assertNotIn("参考来源", out)
+
+
+# =====================================================================
+# 6. research() 错误路径
+# =====================================================================
+class TestResearchErrors(YoucomServiceTestCase):
+    def test_missing_key(self):
+        svc = YoucomService(api_key="")
+        svc._client.post = MagicMock()
+        out = svc.research("q")
+        self.assertIn("未配置 You.com API Key", out)
+        svc._client.post.assert_not_called()
+
+    def test_401(self):
+        self.svc._client.post.return_value = make_http_status_error(401)
+        out = self.svc.research("q")
+        self.assertIn("401", out)
+        self.assertKeyNotLeaked(out)
+
+    def test_429(self):
+        self.svc._client.post.return_value = make_http_status_error(429)
+        out = self.svc.research("q")
+        self.assertIn("429", out)
+        self.assertKeyNotLeaked(out)
+
+    def test_500(self):
+        self.svc._client.post.return_value = make_http_status_error(500)
+        out = self.svc.research("q")
+        self.assertIn("500", out)
+        self.assertKeyNotLeaked(out)
+
+    def test_timeout(self):
+        self.svc._client.post.side_effect = httpx.TimeoutException("timed out")
+        out = self.svc.research("q")
+        self.assertIn("超时", out)
+        self.assertKeyNotLeaked(out)
+
+    def test_malformed_json(self):
+        self.svc._client.post.return_value = make_response(
+            json_raises=json.JSONDecodeError("Expecting value", "doc", 0)
+        )
+        out = self.svc.research("q")
+        self.assertIn("解析失败", out)
+        self.assertKeyNotLeaked(out)
+
+
+# =====================================================================
+# 7. 对抗性输入
+# =====================================================================
+class TestAdversarialInputs(YoucomServiceTestCase):
+    def test_search_whitespace_query_short_circuits(self):
+        out = self.svc.search("   \t\n  ")
+        self.assertIn("不能为空", out)
+        self.svc._client.get.assert_not_called()
+
+    def test_research_whitespace_query_short_circuits(self):
+        out = self.svc.research("   ")
+        self.assertIn("不能为空", out)
+        self.svc._client.post.assert_not_called()
+
+    def test_search_none_query(self):
+        out = self.svc.search(None)
+        self.assertIn("不能为空", out)
+        self.svc._client.get.assert_not_called()
+
+    def test_search_huge_query_no_crash(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        huge = "东" * 50000
+        out = self.svc.search(huge)
+        self.assertIsInstance(out, str)
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(len(kwargs["params"]["query"]), 50000)
+
+    def test_search_non_string_int_query_coerced(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        out = self.svc.search(12345)
+        self.assertIsInstance(out, str)
+        _, kwargs = self.svc._client.get.call_args
+        self.assertEqual(kwargs["params"]["query"], "12345")
+
+    def test_search_non_string_list_query_coerced_no_crash(self):
+        self.svc._client.get.return_value = make_response({"results": {}})
+        out = self.svc.search(["东京", "京都"])
+        self.assertIsInstance(out, str)
+        self.svc._client.get.assert_called_once()
+
+    def test_research_non_string_query_coerced_no_crash(self):
+        self.svc._client.post.return_value = make_response({"output": {"content": "c"}})
+        out = self.svc.research(3.14)
+        self.assertIsInstance(out, str)
+        self.svc._client.post.assert_called_once()
+
+    def test_key_never_in_output_across_error_matrix(self):
+        scenarios = [
+            ("timeout", httpx.TimeoutException("boom")),
+            ("connect", httpx.ConnectError("boom")),
+            ("runtime", RuntimeError(f"leaked {SECRET_KEY} maybe")),
+        ]
+        for label, exc in scenarios:
+            with self.subTest(label=label):
+                self.svc._client.get.side_effect = exc
+                out = self.svc.search("q")
+                self.assertKeyNotLeaked(out)
+
+        for status in (401, 403, 422, 429, 500):
+            with self.subTest(status=status):
+                self.svc._client.get.side_effect = None
+                self.svc._client.get.return_value = make_http_status_error(status)
+                out = self.svc.search("q")
+                self.assertKeyNotLeaked(out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
关联 Issue: https://github.com/1sdv/TripStar/issues/35

## 动机

行程规划 Agent 现有的高德/Google 工具提供地图数据（POI、天气、地理编码），但拿不到「地图之外的实时信息」——活动、最新营业/闭馆、签证入境、旅行提示、"2026 年最佳旅行季节"、行程灵感等。本 PR 新增 **You.com 搜索/研究工具**补上这块，纯增量、按 Key 挂载，不改动现有地图供应商逻辑。

## 变更内容

- 新增 `backend/app/services/youcom_service.py`（自包含，仅依赖 httpx）：
  - `search()` → `GET https://ydc-index.io/v1/search`（`X-API-Key`，映射 `results.web[]`/`news[]` 为结构化文本，数量上限 20）
  - `research()` → `POST https://api.you.com/v1/research`（lite，返回结论 + 编号来源）
  - 未配置 Key 返回清晰中文提示；HTTP/超时/解析异常都转为干净消息；**绝不泄露 Key、绝不抛出未捕获异常**。
- `trip_planner_agent.py`：参照现有 GoogleMaps 的鸭子类型封装，新增 `YoucomNativeTool`（子工具 `youcom_web_search` / `youcom_research`），**仅当 `youcom_api_key` 配置时挂载到 planner_agent**；`map_provider` 与 amap/google 初始化逻辑完全未改动（diff 可查，纯新增方法）。
- `config.py`：新增 `youcom_api_key`（Settings + 运行时配置键 + 前端设置项，三处对齐 google_maps_api_key）；`.env.example`/README 补充说明。

## 质量保证（严格深度测试）

- 标准库 `unittest`，**74 个用例全部通过**（无新增依赖）：请求构造、结果映射（网页/新闻/缺字段/空/null 防御/中文）、错误路径（401/403/422/429/5xx/超时/异常 JSON）、数量上限、research 路径与来源、对抗性输入；并对工具封装做了 10 个用例。
- **变异测试验证测试有效性**：故意注入 3 处缺陷（上限 20→25 / 去掉脱敏 / 模拟 `str(e)` 泄露），确认对应用例都会失败，再还原（byte-identical）复跑全绿——证明测试真的能挡住回归与 Key 泄露。
- 真实端到端：`search`/`research` 均返回真实结果（如京都 2026 红叶最佳时间），未配置 Key 时零网络调用、返回干净提示、Key 不出现在任何输出中。

```bash
python3 -m unittest discover -s backend/tests -v
```

---

**English summary**: Adds a You.com Search/Research tool to the trip-planner agent for live travel info beyond map data (events, hours, visas, advisories, itinerary research). New self-contained youcom_service.py (search -> ydc-index.io/v1/search, research -> api.you.com/v1/research), registered as a duck-typed tool mirroring the existing GoogleMaps wrapper and mounted only when youcom_api_key is set — amap/google provider logic untouched (additive only). 74 stdlib unittest cases (mapping, all error paths, adversarial) plus mutation testing to prove the suite catches regressions and key leaks; verified end-to-end live. No new dependencies; key never leaked.
