### PR TITLE
修复 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,11 +297,11 @@ TripStar/
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=1sdv%2FTripStar&type=date&logscale=&legend=top-left">
+<a href="https://star-history.dera.page/#1sdv/TripStar&type=date&logscale=&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=1sdv/TripStar&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=1sdv/TripStar&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=1sdv/TripStar&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/image?repos=1sdv/TripStar&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/image?repos=1sdv/TripStar&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/image?repos=1sdv/TripStar&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README_en.md
+++ b/README_en.md
@@ -264,11 +264,11 @@ TripStar/
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=1sdv%2FTripStar&type=date&logscale=&legend=top-left">
+<a href="https://star-history.dera.page/#1sdv/TripStar&type=date&logscale=&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=1sdv/TripStar&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=1sdv/TripStar&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=1sdv/TripStar&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/image?repos=1sdv/TripStar&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/image?repos=1sdv/TripStar&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/image?repos=1sdv/TripStar&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
当前 README 中的 Star History 图表链接已失效，无法正常展示项目 Star 趋势。本次更新将 README.md 与 README_en.md 中的图表迁移至新域名，并改用 hash 形式链接，确保图表重新正常工作。