### PR TITLE
fix: normalize start.sh line endings in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ COPY --from=frontend-builder /build/dist ./frontend/dist
 
 # 复制启动脚本
 COPY start.sh ./start.sh
-RUN chmod +x ./start.sh
+RUN sed -i 's/\r$//' ./start.sh && chmod +x ./start.sh
 
 # 魔搭创空间要求端口 7860
 EXPOSE 7860


### PR DESCRIPTION
## What does this PR do?

Normalize CRLF line endings in `start.sh` during the Docker image build before making it executable.

## Why is this change needed?

On Windows with `core.autocrlf=true`, `start.sh` can be copied into the image with CRLF line endings. Linux then reads the shebang as `/bin/bash\r`, causing:

```
exec ./start.sh: no such file or directory
```

This leaves the Compose service in a restart loop.

## Related Issues

Fixes #41

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Testing

- Ran `docker compose up -d --build`
- Confirmed the container status is `Up`
- Confirmed Gunicorn is listening on `0.0.0.0:7860` and application startup completed

## Checklist

- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] Documentation updated if needed
- [x] No breaking changes introduced