### PR TITLE
docs: 替换 Star History 为动态图表并新增贡献者章节

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,21 @@ TripStar/
 
 
 ## Star History
-<img width="869" height="611" alt="image" src="https://github.com/user-attachments/assets/7ca4e182-c3b3-47ac-9797-2e1867130660" />
+
+<a href="https://www.star-history.com/?repos=1sdv%2Ftripstar&type=date&legend=bottom-right">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=1sdv/tripstar&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=1sdv/tripstar&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=1sdv/tripstar&type=date&legend=top-left" />
+ </picture>
+</a>
+
+
+## 贡献者
+
+<a href="https://github.com/1sdv/TripStar/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=1sdv/TripStar" />
+</a>
 
 
 ## 🙏 致谢

--- a/README_en.md
+++ b/README_en.md
@@ -309,7 +309,20 @@ TripStar/
 
 ## Star History
 
-<img width="869" height="611" alt="image" src="https://github.com/user-attachments/assets/d4fa1360-c309-46b0-80fe-bc8fe44f26b1" />
+<a href="https://www.star-history.com/?repos=1sdv%2Ftripstar&type=date&legend=bottom-right">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=1sdv/tripstar&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=1sdv/tripstar&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=1sdv/tripstar&type=date&legend=top-left" />
+ </picture>
+</a>
+
+
+## Contributors
+
+<a href="https://github.com/1sdv/TripStar/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=1sdv/TripStar" />
+</a>
 
 
 ## 🙏 Acknowledgements

--- a/README_ja.md
+++ b/README_ja.md
@@ -241,5 +241,22 @@ npm run dev
 - [x] ~~マルチ都市の旅行計画構成~~
 - [ ] グルメ・おすすめレストランの詳細な強化
 
+## Star History
+
+<a href="https://www.star-history.com/?repos=1sdv%2Ftripstar&type=date&legend=bottom-right">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=1sdv/tripstar&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=1sdv/tripstar&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=1sdv/tripstar&type=date&legend=top-left" />
+ </picture>
+</a>
+
+## コントリビューター
+
+<a href="https://github.com/1sdv/TripStar/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=1sdv/TripStar" />
+</a>
+
+
 ## 🙏 謝辞
 TripStarの改良において交流およびフィードバックをしていただいた [linuxdo](https://linux.do/) コミュニティに感謝します。


### PR DESCRIPTION
## What does this PR do?

Replaces the static Star History screenshots in all three READMEs with the live star-history.com chart, and adds a Contributors section backed by contrib.rocks.

## Why is this change needed?

The Star History images were static screenshots that went stale the moment they were taken. The `<picture>` element now serves the live chart and switches automatically between light and dark color schemes.

`README_ja.md` had no Star History section at all, so it was added there for parity with the other two.

The Contributors avatar wall is generated from the GitHub contributors list, so it stays current with no manual upkeep.

## Type of Change

- [x] Documentation

## Testing

Docs-only change; no code paths affected. Chart and avatar URLs were verified to be well-formed and to point at `1sdv/TripStar`.

Note: the three READMEs were normalized from CRLF to LF in this commit so the diff shows only real content changes (46 insertions, 2 deletions) rather than several hundred lines of line-ending churn.

## Checklist

- [x] Code follows project style guidelines
- [x] Tests pass locally (n/a - docs only)
- [x] Documentation updated (if needed)
- [x] No breaking changes introduced
